### PR TITLE
Add Docker environment and usage docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+**/__pycache__
+**/*.py[cod]
+**/*.so
+**/*.o
+pytest_cache
+.mypy_cache
+__pycache__
+*.pkl
+*.pt
+*.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile for OSRS PvP Reinforcement Learning
+
+# Use micromamba for lightweight conda environment management
+FROM mambaorg/micromamba:1.5.1
+
+# Create working directory
+WORKDIR /app
+
+# Copy environment definition and install dependencies
+COPY pvp-ml/environment.yml /tmp/environment.yml
+RUN micromamba install -y -n pvpml -f /tmp/environment.yml \
+    && micromamba clean --all --yes
+
+# Ensure environment binaries are on PATH
+ENV PATH="/opt/conda/envs/pvpml/bin:$PATH"
+
+# Copy repository code
+COPY . /app
+
+# Default to bash shell when starting container
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,51 @@ Evaluation footage:\
 By following these steps, you'll be able to set up the environment and start training your own AI agent. You'll also
 be able to serve the pre-trained models via an API.
 
+## Run with Docker
+
+If you prefer not to install the project dependencies directly on your machine, a Docker configuration is provided.
+This image contains all Python and Java requirements for both the training system and the simulation server.
+
+### Build the Image
+
+```bash
+docker build -t osrs-pvp-rl .
+```
+
+### Start a Container
+
+GPU (requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)):
+
+```bash
+docker run --gpus all -it -p 43594:43594 osrs-pvp-rl
+```
+
+CPU only:
+
+```bash
+docker run -it -p 43594:43594 osrs-pvp-rl
+```
+
+The container drops you into a shell with the `pvp-ml` conda environment activated. Typical workflow:
+
+1. **Launch the simulation server**
+
+   ```bash
+   cd simulation-rsps/ElvargServer
+   ./gradlew run
+   ```
+
+2. **Open another shell in the running container** (e.g. `docker exec -it <container-id> bash`) and start training or
+   evaluation from the `pvp-ml` project:
+
+   ```bash
+   cd /app/pvp-ml
+   train --preset PastSelfPlay --name demo        # example training run
+   # or serve-api, eval, etc.
+   ```
+
+Port `43594` is forwarded for the simulation server so that local RSPS clients can connect if desired.
+
 ## [PvP ML](pvp-ml)
 
 This Python-based component encompasses the core machine learning system. It's the primary interface for training,

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ be able to serve the pre-trained models via an API.
 If you prefer not to install the project dependencies directly on your machine, a Docker configuration is provided.
 This image contains all Python and Java requirements for both the training system and the simulation server.
 
+### Prerequisites (Windows 11)
+
+1. Enable the Windows Subsystem for Linux (WSL) and install a Linux distribution:
+   ```powershell
+   wsl --install
+   ```
+2. Download and install [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/).
+3. Launch Docker Desktop and ensure it is running with the **WSL 2** backend.
+4. Verify the installation from a terminal or PowerShell:
+   ```powershell
+   docker --version
+   ```
+
 ### Build the Image
 
 ```bash


### PR DESCRIPTION
## Summary
- add Dockerfile with micromamba environment for Python and Java dependencies
- document building and running the project in a Docker container

## Testing
- `PYTHONPATH=pvp-ml pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6895462ef130832db30a251f99827178