### PR TITLE
docs: add Windows NVIDIA toolkit setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ This image contains all Python and Java requirements for both the training syste
    docker --version
    ```
 
+5. Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) for GPU support:
+   1. Ensure the latest NVIDIA GPU driver is installed on Windows and reboot if required.
+   2. Open your WSL distribution (e.g. Ubuntu) and add the repository and package:
+      ```bash
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+      curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+      curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+        sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+      sudo apt-get update
+      sudo apt-get install -y nvidia-container-toolkit
+      ```
+   3. Configure Docker to use the NVIDIA runtime and restart Docker Desktop:
+      ```bash
+      sudo nvidia-ctk runtime configure --runtime=docker
+      sudo service docker restart   # or restart from the Docker Desktop UI
+      ```
+
 ### Build the Image
 
 ```bash


### PR DESCRIPTION
## Summary
- document NVIDIA Container Toolkit setup for WSL-based Windows installs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68969aad5ac8832db1661b34f3b3c9b6