### PR TITLE
docs: add Windows NVIDIA toolkit setup instructions and fix micromamba build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,19 @@ FROM mambaorg/micromamba:1.5.1
 # Create working directory
 WORKDIR /app
 
-# Copy environment definition and install dependencies
-COPY pvp-ml/environment.yml /tmp/environment.yml
-RUN micromamba install -y -n pvpml -f /tmp/environment.yml \
+# Copy source needed for environment creation
+COPY pvp-ml /app/pvp-ml
+
+# Create conda environment from specification
+WORKDIR /app/pvp-ml
+RUN micromamba create -y -f environment.yml \
     && micromamba clean --all --yes
 
 # Ensure environment binaries are on PATH
-ENV PATH="/opt/conda/envs/pvpml/bin:$PATH"
+ENV PATH="/opt/conda/envs/pvp/bin:$PATH"
 
 # Copy repository code
+WORKDIR /app
 COPY . /app
 
 # Default to bash shell when starting container

--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ This image contains all Python and Java requirements for both the training syste
    docker --version
    ```
 
+5. Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) for GPU support:
+   1. Ensure the latest NVIDIA GPU driver is installed on Windows and reboot if required.
+   2. Open your WSL distribution (e.g. Ubuntu) and add the repository and package:
+      ```bash
+      distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+      curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+      curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+        sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+      sudo apt-get update
+      sudo apt-get install -y nvidia-container-toolkit
+      ```
+   3. Configure Docker to use the NVIDIA runtime and restart Docker Desktop:
+      ```bash
+      sudo nvidia-ctk runtime configure --runtime=docker
+      sudo service docker restart   # or restart from the Docker Desktop UI
+      ```
+
+Double-click `windows-setup-check.bat` to automatically verify these prerequisites and install missing components. After setup completes, `run-demo.bat` builds the image and prints the installed PyTorch version inside the container as a quick demonstration.
+
 ### Build the Image
 
 ```bash

--- a/run-demo.bat
+++ b/run-demo.bat
@@ -1,0 +1,4 @@
+@echo off
+docker build -t osrs-pvp-rl .
+docker run --rm osrs-pvp-rl bash -lc "python -c \"import torch; print('Torch version:', torch.__version__)\""
+pause

--- a/windows-setup-check.bat
+++ b/windows-setup-check.bat
@@ -1,0 +1,60 @@
+@echo off
+SETLOCAL EnableDelayedExpansion
+
+echo Checking Windows 11 prerequisites for OSRS PvP RL...
+
+REM Check WSL
+wsl.exe -l -q >NUL 2>&1
+if ERRORLEVEL 1 (
+    echo WSL not detected.
+    set /p wslInstall="Install WSL now? (Y/N): "
+    if /I "!wslInstall!"=="Y" (
+        wsl --install
+    ) else (
+        echo Skipping WSL installation.
+    )
+) else (
+    echo WSL is installed.
+)
+
+REM Check Docker
+docker --version >NUL 2>&1
+if ERRORLEVEL 1 (
+    echo Docker Desktop not found.
+    set /p dockerInstall="Open Docker Desktop download page? (Y/N): "
+    if /I "!dockerInstall!"=="Y" (
+        start https://docs.docker.com/desktop/install/windows-install/
+    )
+) else (
+    echo Docker Desktop is installed.
+)
+
+REM Check NVIDIA driver
+nvidia-smi >NUL 2>&1
+if ERRORLEVEL 1 (
+    echo NVIDIA GPU driver not detected.
+    set /p driverInstall="Open NVIDIA driver download page? (Y/N): "
+    if /I "!driverInstall!"=="Y" (
+        start https://www.nvidia.com/Download/index.aspx
+    )
+) else (
+    echo NVIDIA GPU driver detected.
+)
+
+REM Check NVIDIA Container Toolkit
+wsl -e nvidia-container-cli -V >NUL 2>&1
+if ERRORLEVEL 1 (
+    echo NVIDIA Container Toolkit not detected in WSL.
+    set /p toolkitInstall="Install NVIDIA Container Toolkit now? (Y/N): "
+    if /I "!toolkitInstall!"=="Y" (
+        wsl -e bash -lc "distribution=\$(. /etc/os-release;echo \$ID\$VERSION_ID) ^&^& curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey ^| sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg ^&^& curl -s -L https://nvidia.github.io/libnvidia-container/\$distribution/libnvidia-container.list ^| sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' ^| sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list ^&^& sudo apt-get update ^&^& sudo apt-get install -y nvidia-container-toolkit ^&^& sudo nvidia-ctk runtime configure --runtime=docker ^&^& sudo service docker restart"
+    ) else (
+        echo Skipping toolkit installation.
+    )
+) else (
+    echo NVIDIA Container Toolkit detected.
+)
+
+echo.
+echo Setup check complete.
+pause


### PR DESCRIPTION
## Summary
- document NVIDIA Container Toolkit setup for WSL-based Windows installs
- fix Dockerfile to create micromamba environment before copying project code
- add batch scripts for Windows prerequisite checks and a quick PyTorch demo

## Testing
- `pre-commit run --files README.md run-demo.bat windows-setup-check.bat -c pvp-ml/.pre-commit-config.yaml` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128, HTTP 403)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68969aad5ac8832db1661b34f3b3c9b6